### PR TITLE
fix: Map legend on dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "author": "macolmenerori",
   "license": "MIT",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.16.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/macolmenerori/cyl-polen-tracker"

--- a/src/components/PollenMap/PollenMap.tsx
+++ b/src/components/PollenMap/PollenMap.tsx
@@ -247,7 +247,7 @@ export function PollenMap({ pollenApiData, selectedPollen }: PollenMapProps) {
               position: 'absolute',
               top: 20,
               right: 20,
-              backgroundColor: 'rgba(255, 255, 255, 0.95)',
+
               backdropFilter: 'blur(10px)',
               padding: 3,
               borderRadius: 2,


### PR DESCRIPTION
### What's new

No new features added...

### What's fixed

- Map legend background was not being synced with the theme, making it impossible to be read on dark theme.

### How to test

- Check out the map legend on dark mode

### Breaking changes

No breaking changes here...
